### PR TITLE
remove global mutex in read operation

### DIFF
--- a/src/main/java/net.mbl.hcfsfuse/HCFSFuse.java
+++ b/src/main/java/net.mbl.hcfsfuse/HCFSFuse.java
@@ -51,7 +51,7 @@ public class HCFSFuse {
     try {
       LOG.info("mounting to {}", opts.getMountPoint());
       fs.mount(Paths.get(opts.getMountPoint()), true, opts.isDebug(),
-          fuseOpts.toArray(new String[0]));
+              fuseOpts.toArray(new String[0]));
     } catch (FuseException e) {
       LOG.error("Failed to mount {}", opts.getMountPoint(), e);
       // only try to umount file system when exception occurred.

--- a/src/main/java/net.mbl.hcfsfuse/HCFSFuseFileSystem.java
+++ b/src/main/java/net.mbl.hcfsfuse/HCFSFuseFileSystem.java
@@ -242,10 +242,9 @@ public class HCFSFuseFileSystem extends FuseStubFS {
     mOpenFiles.add(new OpenFileEntry(fid, path, is, out));
     fi.fh.set(fid);
 
-    LOG.debug("Open: " + path
-        + "|ProcessId: " + Utils.getProcessId()
-        + "|ThreadId: " + Utils.getThreadId()
-        + "|fid: " + fid + "|is address: " + System.identityHashCode(is));
+    LOG.debug("Open: {} |ProcessId: {}|ThreadId: {}|fid: {}|is address: {}",
+            path,  Utils.getProcessId(), Utils.getThreadId(), fid,
+            System.identityHashCode(is));
 
     return 0;
   }

--- a/src/main/java/net/mbl/hcfsfuse/utils/Utils.java
+++ b/src/main/java/net/mbl/hcfsfuse/utils/Utils.java
@@ -1,0 +1,37 @@
+package net.mbl.hcfsfuse.utils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+
+/**
+ * @author leoncao
+ * 2021/1/25
+ */
+public class Utils {
+  /**
+   * Get current process id.
+   * @return Long
+   */
+  public static Long getProcessId() {
+    try {
+      RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+      String name = runtime.getName();
+      String pid = name.substring(0, name.indexOf('@'));
+      return Long.parseLong(pid);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Get current thread id.
+   * * @return Long
+   */
+  public static Long getThreadId() {
+    try {
+      return Thread.currentThread().getId();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/net/mbl/hcfsfuse/utils/Utils.java
+++ b/src/main/java/net/mbl/hcfsfuse/utils/Utils.java
@@ -1,0 +1,37 @@
+package net.mbl.hcfsfuse.utils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+
+/**
+ * @author leoncao
+ * 2021/1/25
+ */
+public class Utils {
+  /**
+   * 获取当前进程ID.
+   * @return Long
+   */
+  public static Long getProcessId() {
+    try {
+      RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+      String name = runtime.getName();
+      String pid = name.substring(0, name.indexOf('@'));
+      return Long.parseLong(pid);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * 获取当前线程ID.
+   * * @return Long
+   */
+  public static Long getThreadId() {
+    try {
+      return Thread.currentThread().getId();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Background: Global locking was used in the original read operation, which caused read operations to be unable to concurrency even between different open files
Modify: Change the existing global lock to lock on the read stream object of the open file