### PR TITLE
Update the version of jnr-fuse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
-        <version>0.5.4</version>
+        <version>0.5.5</version>
         <exclusions>
           <exclusion>
             <artifactId>jnr-constants</artifactId>


### PR DESCRIPTION
Update the version of jnr-fuse to solve the following error:
```
Could not find artifact com.github.serceman:jnr-fuse:jar:0.5.4
```