### PR TITLE
add temporary fix for mkdir group name

### DIFF
--- a/src/main/java/hcfsfuse/fuse/AuthConstants.java
+++ b/src/main/java/hcfsfuse/fuse/AuthConstants.java
@@ -8,4 +8,5 @@ public class AuthConstants {
   public static final String AUTH_POLICY_CUSTOM = "custom";
   public static final String AUTH_POLICY_CUSTOM_USER = "hcfs.fuse.auth.custom.user";
   public static final String AUTH_POLICY_CUSTOM_GROUP = "hcfs.fuse.auth.custom.group";
+  public static final String AUTH_POLICY_IGNORE_MKDIR_GROUP = "hcfs.fuse.ignore.mkdir.group";
 }


### PR DESCRIPTION
The context is that when we use fuse to mkdir on mounted dir of odfs cluster,  an error is thrown, "runzhiwang is not a member of runzhiwang". According to the code  `mFileSystem.mkdirs(turi, new FsPermission((int) mode));
      mFileSystem.setOwner(turi, userName, groupName);`, the fuse will mkdir and then setowner of the dir. The error above is due to code[1] in odfs, where the group sent here is not null as fuse will send its groupName to odfs and it is not in Namenode's local groups. Thus the dir is set up and the error is also thrown. Here is the solution to add a configurable field that allows the groupName sent in  `setowner` is null for odfs.

[1]`    if (group != null && !pc.isMemberOfGroup(group)) {
          throw new AccessControlException(
              "User " + pc.getUser() + " does not belong to " + group);
        }`
