### PR TITLE
support ozone 1.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,17 @@
     <log4j.version>2.5</log4j.version>
 
     <alluxio.version>2.6.1</alluxio.version>
+    <!-- for tbds
+    <hadoop.version>3.2.1-TBDS-SNAPSHOT</hadoop.version>-->
+    <!--for tq hadoop -->
     <hadoop.version>3.2.1</hadoop.version>
-    <ozone.version>1.1.0</ozone.version>
+    <ozone.version>1.2.0</ozone.version>
+    <!-- Test package version 1.2.0-tq-0.4.0 hdds-common-1.2.0-SNAPSHOT.jar-->
     <!-- Test package version -->
     <version.mock>1.38</version.mock>
     <zookeeper.version>3.4.14</zookeeper.version>
     <odfs.version>1.0.4</odfs.version>
+    <metrics.core.version>3.2.4</metrics.core.version>
   </properties>
 
   <repositories>
@@ -114,13 +119,13 @@
         <version>${alluxio.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-ozone-client</artifactId>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-client</artifactId>
         <version>${ozone.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-ozone-filesystem</artifactId>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem</artifactId>
         <version>${ozone.version}</version>
       </dependency>
       <dependency>
@@ -132,6 +137,11 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>${zookeeper.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${metrics.core.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -367,8 +377,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-client</artifactId>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-client</artifactId>
       <exclusions>
         <exclusion>
           <artifactId>netty-all</artifactId>
@@ -385,13 +395,18 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-filesystem</artifactId>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-filesystem</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+
   </dependencies>
   <build>
     <pluginManagement>


### PR DESCRIPTION
Support ozone 1.2.x. The package name of Ozone needs to be change，we need to remove the hadoop prefix.